### PR TITLE
Update go.mod to allow "go run" without installation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module EverydayRoadster/CaliExportGpxer
+module github.com/EverydayRoadster/CaliExportGpxer
 
 go 1.21.3
 


### PR DESCRIPTION
This allows running the tool as just

    go run github.com/EverydayRoadster/CaliExportGpxer@latest .